### PR TITLE
feat: integrate tmdb and tvdb services

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ tinyMediaManager is free and will stay free. If you appreciate all the effort th
 ##Version 2##
 Version 2.6.8 has been released on 08. June 2015.
 
+This fork adds optional metadata scraping from [The Movie Database](https://www.themoviedb.org) and [The TVDB](http://thetvdb.com) alongside the existing IMDB integration.
+
 ##Features##
 [http://www.tinymediamanager.org/index.php/features/](http://www.tinymediamanager.org/index.php/features/)
 

--- a/src/org/tinymediamanager/scraper/MediaArtwork.java
+++ b/src/org/tinymediamanager/scraper/MediaArtwork.java
@@ -175,6 +175,7 @@ public class MediaArtwork {
 
   private String                imdbId;
   private int                   tmdbId;
+  private int                   tvdbId;
   private int                   season     = -1;
   private String                previewUrl = "";
   private String                defaultUrl = "";
@@ -240,6 +241,14 @@ public class MediaArtwork {
 
   public void setTmdbId(int tmdbId) {
     this.tmdbId = tmdbId;
+  }
+
+  public int getTvdbId() {
+    return tvdbId;
+  }
+
+  public void setTvdbId(int tvdbId) {
+    this.tvdbId = tvdbId;
   }
 
   public String getImdbId() {

--- a/src/org/tinymediamanager/scraper/MediaScrapeOptions.java
+++ b/src/org/tinymediamanager/scraper/MediaScrapeOptions.java
@@ -74,12 +74,27 @@ public class MediaScrapeOptions {
     return id;
   }
 
+  public int getTvdbId() {
+    int id = 0;
+    try {
+      id = Integer.parseInt(ids.get(Constants.TVDBID));
+    }
+    catch (Exception e) {
+      return 0;
+    }
+    return id;
+  }
+
   public void setImdbId(String imdbId) {
     ids.put(Constants.IMDBID, imdbId);
   }
 
   public void setTmdbId(int tmdbId) {
     ids.put(Constants.TMDBID, String.valueOf(tmdbId));
+  }
+
+  public void setTvdbId(int tvdbId) {
+    ids.put(Constants.TVDBID, String.valueOf(tvdbId));
   }
 
   public MediaArtworkType getArtworkType() {

--- a/src/org/tinymediamanager/scraper/MediaSearchOptions.java
+++ b/src/org/tinymediamanager/scraper/MediaSearchOptions.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class MediaSearchOptions {
   public enum SearchParam {
-    QUERY, TITLE, YEAR, IMDBID, TMDBID, SEASON, EPISODE, LANGUAGE, COUNTRY, COLLECTION_INFO, IMDB_FOREIGN_LANGUAGE
+    QUERY, TITLE, YEAR, IMDBID, TMDBID, TVDBID, SEASON, EPISODE, LANGUAGE, COUNTRY, COLLECTION_INFO, IMDB_FOREIGN_LANGUAGE
   };
 
   private Map<SearchParam, String> options = new HashMap<SearchParam, String>();

--- a/src/org/tinymediamanager/scraper/MediaSearchResult.java
+++ b/src/org/tinymediamanager/scraper/MediaSearchResult.java
@@ -38,6 +38,8 @@ public class MediaSearchResult implements Comparable<MediaSearchResult> {
   private float               score;
   private Map<String, String> extraArgs = new HashMap<String, String>();
   private String              imdbId;
+  private int                 tmdbId;
+  private int                 tvdbId;
   private MediaMetadata       metadata  = null;
   private MediaType           type;
   private String              posterUrl;
@@ -61,6 +63,8 @@ public class MediaSearchResult implements Comparable<MediaSearchResult> {
     originalTitle = StringUtils.isEmpty(originalTitle) ? msr.getOriginalTitle() : originalTitle;
     id = StringUtils.isEmpty(id) ? msr.getId() : id;
     imdbId = StringUtils.isEmpty(imdbId) ? msr.getIMDBId() : imdbId;
+    tmdbId = tmdbId == 0 ? msr.getTmdbId() : tmdbId;
+    tvdbId = tvdbId == 0 ? msr.getTvdbId() : tvdbId;
     posterUrl = StringUtils.isEmpty(posterUrl) ? msr.getPosterUrl() : posterUrl;
 
     extraArgs.putAll(msr.getExtra()); // meh - add all
@@ -163,6 +167,22 @@ public class MediaSearchResult implements Comparable<MediaSearchResult> {
 
   public void setIMDBId(String imdbid) {
     this.imdbId = imdbid;
+  }
+
+  public int getTmdbId() {
+    return tmdbId;
+  }
+
+  public void setTmdbId(int tmdbId) {
+    this.tmdbId = tmdbId;
+  }
+
+  public int getTvdbId() {
+    return tvdbId;
+  }
+
+  public void setTvdbId(int tvdbId) {
+    this.tvdbId = tvdbId;
   }
 
   public Map<String, String> getExtra() {

--- a/src/org/tinymediamanager/scraper/thetvdb/TheTvDbMetadataProvider.java
+++ b/src/org/tinymediamanager/scraper/thetvdb/TheTvDbMetadataProvider.java
@@ -69,6 +69,7 @@ public class TheTvDbMetadataProvider implements ITvShowMetadataProvider, IMediaA
   private static TheTVDBApi        tvdb;
   private static MediaProviderInfo providerInfo = new MediaProviderInfo(Constants.TVDBID, "thetvdb.com",
                                                     "Scraper for thetvdb.com which is able to scrape tv series metadata and artwork");
+  private static final String      TVDB_BASE_URL = "http://thetvdb.com/?tab=series&id=";
 
   public TheTvDbMetadataProvider() throws Exception {
     initAPI();
@@ -169,7 +170,14 @@ public class TheTvDbMetadataProvider implements ITvShowMetadataProvider, IMediaA
 
       if (md != null && StringUtils.isNotBlank(md.getStringValue(MediaMetadata.TITLE))) {
         MediaSearchResult result = new MediaSearchResult(providerInfo.getId());
-        result.setId((String) md.getId(providerInfo.getId()));
+        String id = (String) md.getId(providerInfo.getId());
+        result.setId(id);
+        try {
+          result.setTvdbId(Integer.parseInt(id));
+        }
+        catch (NumberFormatException e) {
+        }
+        result.setUrl(TVDB_BASE_URL + id);
         result.setTitle(md.getStringValue(MediaMetadata.TITLE));
         result.setPosterUrl(md.getStringValue(MediaMetadata.POSTER_URL));
         results.add(result);
@@ -205,6 +213,12 @@ public class TheTvDbMetadataProvider implements ITvShowMetadataProvider, IMediaA
   private MediaSearchResult createSearchResult(Series show, MediaSearchOptions options, String searchString) {
     MediaSearchResult sr = new MediaSearchResult(providerInfo.getId());
     sr.setId(show.getId());
+    try {
+      sr.setTvdbId(Integer.parseInt(show.getId()));
+    }
+    catch (NumberFormatException e) {
+    }
+    sr.setUrl(TVDB_BASE_URL + show.getId());
     sr.setIMDBId(show.getImdbId());
     sr.setTitle(show.getSeriesName());
     sr.setPosterUrl(show.getPoster());
@@ -228,7 +242,20 @@ public class TheTvDbMetadataProvider implements ITvShowMetadataProvider, IMediaA
 
     // id from result
     if (options.getResult() != null) {
-      id = options.getResult().getId();
+      if (options.getResult().getTvdbId() > 0) {
+        id = String.valueOf(options.getResult().getTvdbId());
+      }
+      else {
+        id = options.getResult().getId();
+      }
+    }
+
+    // id from options (numeric field)
+    if (StringUtils.isEmpty(id)) {
+      int nid = options.getTvdbId();
+      if (nid > 0) {
+        id = String.valueOf(nid);
+      }
     }
 
     // do we have an id from the options?
@@ -327,7 +354,20 @@ public class TheTvDbMetadataProvider implements ITvShowMetadataProvider, IMediaA
 
     // id from result
     if (options.getResult() != null) {
-      id = options.getResult().getId();
+      if (options.getResult().getTvdbId() > 0) {
+        id = String.valueOf(options.getResult().getTvdbId());
+      }
+      else {
+        id = options.getResult().getId();
+      }
+    }
+
+    // id from options (numeric field)
+    if (StringUtils.isEmpty(id)) {
+      int nid = options.getTvdbId();
+      if (nid > 0) {
+        id = String.valueOf(nid);
+      }
     }
 
     // do we have an id from the options?

--- a/src/org/tinymediamanager/scraper/tmdb/TmdbMetadataProvider.java
+++ b/src/org/tinymediamanager/scraper/tmdb/TmdbMetadataProvider.java
@@ -75,6 +75,7 @@ public class TmdbMetadataProvider implements IMediaMetadataProvider, IMediaArtwo
   private static final Logger           LOGGER            = LoggerFactory.getLogger(TmdbMetadataProvider.class);
   private static final RingBuffer<Long> connectionCounter = new RingBuffer<Long>(30);
   private static final String           apiKey            = "6247670ec93f4495a36297ff88f7cd15";
+  private static final String           TMDB_BASE_URL     = "https://www.themoviedb.org/movie/";
 
   private static TheMovieDbApi          tmdb;
   private static MediaProviderInfo      providerInfo      = new MediaProviderInfo(Constants.TMDBID, "themoviedb.org",
@@ -227,6 +228,8 @@ public class TmdbMetadataProvider implements IMediaMetadataProvider, IMediaArtwo
       if (movie != null) {
         MediaSearchResult sr = new MediaSearchResult(providerInfo.getId());
         sr.setId(Integer.toString(movie.getId()));
+        sr.setTmdbId(movie.getId());
+        sr.setUrl(TMDB_BASE_URL + movie.getId());
         sr.setIMDBId(movie.getImdbID());
         sr.setTitle(movie.getTitle());
         sr.setOriginalTitle(movie.getOriginalTitle());
@@ -288,7 +291,14 @@ public class TmdbMetadataProvider implements IMediaMetadataProvider, IMediaArtwo
 
     // tmdbId from searchResult
     if (options.getResult() != null) {
-      tmdbId = Integer.parseInt(options.getResult().getId());
+      tmdbId = options.getResult().getTmdbId();
+      if (tmdbId == 0) {
+        try {
+          tmdbId = Integer.parseInt(options.getResult().getId());
+        }
+        catch (NumberFormatException e) {
+        }
+      }
     }
 
     // tmdbId from option
@@ -508,7 +518,14 @@ public class TmdbMetadataProvider implements IMediaMetadataProvider, IMediaArtwo
 
     // tmdbId from searchResult
     if (options.getResult() != null) {
-      tmdbId = Integer.parseInt(options.getResult().getId());
+      tmdbId = options.getResult().getTmdbId();
+      if (tmdbId == 0) {
+        try {
+          tmdbId = Integer.parseInt(options.getResult().getId());
+        }
+        catch (NumberFormatException e) {
+        }
+      }
     }
 
     // tmdbId from option


### PR DESCRIPTION
## Summary
- add base URLs and ID handling for TMDB and TVDB search results
- honor tmdb/tvdb identifiers when scraping metadata
- document support for TMDB and TVDB in README

## Testing
- `javac -cp "$(find lib -name '*.jar' | tr '\n' ':')src" src/org/tinymediamanager/scraper/tmdb/TmdbMetadataProvider.java src/org/tinymediamanager/scraper/thetvdb/TheTvDbMetadataProvider.java -d /tmp/classes` *(fails: package javax.xml.bind.annotation does not exist)*
- `ant package-app` *(fails: command not found: ant)*
- `apt-get update` *(fails: repository is not signed)*